### PR TITLE
parse number next to EXTINF as duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ main() async {
 ## Missing features
 
 - [ ] Parse from a stream of data instead of a string
-- [ ] Parse the number next to the EXTINF Ex: `#EXTINF:-1`
 - [ ] Parse info from the header
 - [ ] Parse start track info
 - [ ] Parse non string information ex: `aspect-ratio=4:3`

--- a/example/main.dart
+++ b/example/main.dart
@@ -4,7 +4,7 @@ import 'package:m3u/m3u.dart';
 
 Future<void> main(List<String> arguments) async {
   final fileContent = await File('resources/example.m3u').readAsString();
-  final List<M3uGenericEntry> listOfTracks = await parseFile(fileContent);
+  final listOfTracks = await parseFile(fileContent);
   print(listOfTracks);
 
   // Organized categories

--- a/lib/m3u.dart
+++ b/lib/m3u.dart
@@ -21,8 +21,8 @@ Future<List<M3uGenericEntry>> parseFile(String source) async =>
 /// [defaultAttribute] when the attribute is not found category
 /// to merge properties.
 Map<String, List<M3uGenericEntry>> sortedCategories(
-        {@required List<M3uGenericEntry> entries,
-        @required String attributeName,
+        {required List<M3uGenericEntry> entries,
+        required String attributeName,
         String defaultAttribute = 'other'}) =>
     PlaylistHelper.sortedCategories(
         entries: entries,

--- a/lib/src/entries/generic_entry.dart
+++ b/lib/src/entries/generic_entry.dart
@@ -34,7 +34,7 @@ class M3uGenericEntry {
   String link;
 
   /// Duration is the seconds in the numeric part of `#EXTINF:191`
-  /// It is -1 if not present or parsing fails
+  /// It is null if not present or parsing fails
   int duration;
 
   /// Simple representation of the object on a string.

--- a/lib/src/entries/generic_entry.dart
+++ b/lib/src/entries/generic_entry.dart
@@ -8,7 +8,7 @@ class M3uGenericEntry {
   /// [title] of the track/stream
   /// [attributes] custom attributes, can be null
   /// [link] the link to the source of the track/stream
-  M3uGenericEntry({this.title, this.attributes, this.link});
+  M3uGenericEntry({this.title, this.attributes, this.link, this.duration});
 
   /// Constructor from an [EntryInformation] that only hold the title
   /// and attributes of a track/stream
@@ -17,7 +17,8 @@ class M3uGenericEntry {
       M3uGenericEntry(
           title: information.title,
           attributes: information.attributes,
-          link: link);
+          link: link,
+          duration: information.duration);
 
   /// Hold the information about the track.
   /// This is a raw string there are some formats specific to playlists, but
@@ -31,6 +32,10 @@ class M3uGenericEntry {
 
   /// Source of the track/stream url that points to a track/stream
   String link;
+
+  /// Duration is the seconds in the numeric part of `#EXTINF:191`
+  /// It is -1 if not present or parsing fails
+  int duration;
 
   /// Simple representation of the object on a string.
   @override

--- a/lib/src/entries/generic_entry.dart
+++ b/lib/src/entries/generic_entry.dart
@@ -8,12 +8,13 @@ class M3uGenericEntry {
   /// [title] of the track/stream
   /// [attributes] custom attributes, can be null
   /// [link] the link to the source of the track/stream
-  M3uGenericEntry({this.title, this.attributes, this.link});
+  M3uGenericEntry(
+      {required this.title, required this.attributes, required this.link});
 
   /// Constructor from an [EntryInformation] that only hold the title
   /// and attributes of a track/stream
   factory M3uGenericEntry.fromEntryInformation(
-          {EntryInformation information, String link}) =>
+          {required EntryInformation information, required String link}) =>
       M3uGenericEntry(
           title: information.title,
           attributes: information.attributes,
@@ -27,7 +28,7 @@ class M3uGenericEntry {
   /// Attributes parsed from the line of metadata
   /// Ex:
   /// `#EXTINF:-1 tvg-id="identifier" group-title="The Only one",A TV channel`
-  Map<String, String> attributes;
+  Map<String, String?> attributes;
 
   /// Source of the track/stream url that points to a track/stream
   String link;

--- a/lib/src/entry_information.dart
+++ b/lib/src/entry_information.dart
@@ -4,7 +4,7 @@ class EntryInformation {
   /// Base information of the metadata of a stream/track
   /// [title] of the track/stream
   /// [attributes] the attributes of the stream, they can be null
-  EntryInformation({this.title, this.attributes});
+  EntryInformation({this.title, this.attributes, this.duration});
 
   /// Hold the information about the track.
   /// This is a raw string there are some formats specific to playlists, but
@@ -15,4 +15,8 @@ class EntryInformation {
   /// Ex:
   /// `#EXTINF:-1 tvg-id="identifier" group-title="The Only one",A TV channel`
   Map<String, String> attributes;
+
+  /// Duration is the seconds in the numeric part of `#EXTINF:191`
+  /// It is -1 if not present or parsing fails
+  int duration;
 }

--- a/lib/src/entry_information.dart
+++ b/lib/src/entry_information.dart
@@ -4,7 +4,7 @@ class EntryInformation {
   /// Base information of the metadata of a stream/track
   /// [title] of the track/stream
   /// [attributes] the attributes of the stream, they can be null
-  EntryInformation({this.title, this.attributes});
+  EntryInformation({required this.title, required this.attributes});
 
   /// Hold the information about the track.
   /// This is a raw string there are some formats specific to playlists, but
@@ -14,5 +14,5 @@ class EntryInformation {
   /// Attributes parsed from the line of metadata
   /// Ex:
   /// `#EXTINF:-1 tvg-id="identifier" group-title="The Only one",A TV channel`
-  Map<String, String> attributes;
+  Map<String, String?> attributes;
 }

--- a/lib/src/entry_information.dart
+++ b/lib/src/entry_information.dart
@@ -17,6 +17,6 @@ class EntryInformation {
   Map<String, String> attributes;
 
   /// Duration is the seconds in the numeric part of `#EXTINF:191`
-  /// It is -1 if not present or parsing fails
+  /// It is null if not present or parsing fails
   int duration;
 }

--- a/lib/src/exception/invalid_format_exception.dart
+++ b/lib/src/exception/invalid_format_exception.dart
@@ -10,10 +10,10 @@ class InvalidFormatException implements Exception {
   InvalidFormatType formatType;
 
   /// Option extra parameter that represent the value given to throw this error.
-  String originalValue;
+  String? originalValue;
 
   /// Optional message to give more debug options.
-  String customMessage;
+  String? customMessage;
 
   @override
   String toString() {

--- a/lib/src/m3u_parser.dart
+++ b/lib/src/m3u_parser.dart
@@ -88,12 +88,11 @@ class M3uParser {
   /// This parses the metadata information of a line.
   /// This is a Regex parser caution is advised.
   EntryInformation _regexParse(String line) {
-    // print('line $line');
     final regexExpression = RegExp(r' (.*?)=\"(.*?)"|,(.*)');
     final matches = regexExpression.allMatches(line);
     final attributes = <String, String>{};
     var title = '';
-    var duration = -1;
+    int duration;
 
     matches.forEach((match) {
       if (match[1] != null && match[2] != null) {
@@ -108,7 +107,7 @@ class M3uParser {
     final durExpression = RegExp(r'#EXTINF:([-0-9]+)');
     final durMatch = durExpression.firstMatch(line);
     if (durMatch != null) {
-      duration = int.tryParse(durMatch.group(1)) ?? -1;
+      duration = int.tryParse(durMatch.group(1));
     }
 
     return EntryInformation(

--- a/lib/src/m3u_parser.dart
+++ b/lib/src/m3u_parser.dart
@@ -88,10 +88,12 @@ class M3uParser {
   /// This parses the metadata information of a line.
   /// This is a Regex parser caution is advised.
   EntryInformation _regexParse(String line) {
+    // print('line $line');
     final regexExpression = RegExp(r' (.*?)=\"(.*?)"|,(.*)');
     final matches = regexExpression.allMatches(line);
     final attributes = <String, String>{};
     var title = '';
+    var duration = -1;
 
     matches.forEach((match) {
       if (match[1] != null && match[2] != null) {
@@ -102,6 +104,14 @@ class M3uParser {
         print('ERROR regexing against -> ${match[0]}');
       }
     });
-    return EntryInformation(title: title, attributes: attributes);
+
+    final durExpression = RegExp(r'#EXTINF:([-0-9]+)');
+    final durMatch = durExpression.firstMatch(line);
+    if (durMatch != null) {
+      duration = int.tryParse(durMatch.group(1)) ?? -1;
+    }
+
+    return EntryInformation(
+        title: title, attributes: attributes, duration: duration);
   }
 }

--- a/lib/src/m3u_parser.dart
+++ b/lib/src/m3u_parser.dart
@@ -21,14 +21,14 @@ class M3uParser {
       M3uParser()._parse(source);
 
   /// Internally used after the header is parsed.
-  FileTypeHeader _fileType;
+  FileTypeHeader? _fileType;
 
   /// Controller for the current state of the parser
   /// This flag indicates the next type of data that we expect.
   LineParsedType _nextLineExpected = LineParsedType.header;
 
   /// Current holder of the information about the current Track
-  EntryInformation _currentInfoEntry;
+  EntryInformation? _currentInfoEntry;
 
   /// Result accumulator of the parser.
   final List<M3uGenericEntry> _playlist = <M3uGenericEntry>[];
@@ -66,14 +66,14 @@ class M3uParser {
           break;
         }
         _playlist.add(M3uGenericEntry.fromEntryInformation(
-            information: _currentInfoEntry, link: line));
+            information: _currentInfoEntry!, link: line));
         _currentInfoEntry = null;
         _nextLineExpected = LineParsedType.info;
         break;
     }
   }
 
-  EntryInformation _parseInfoRow(String line, FileTypeHeader fileType) {
+  EntryInformation? _parseInfoRow(String line, FileTypeHeader? fileType) {
     switch (fileType) {
       case FileTypeHeader.m3u:
         return _regexParse(line);
@@ -90,18 +90,18 @@ class M3uParser {
   EntryInformation _regexParse(String line) {
     final regexExpression = RegExp(r' (.*?)=\"(.*?)"|,(.*)');
     final matches = regexExpression.allMatches(line);
-    final attributes = <String, String>{};
-    var title = '';
+    final attributes = <String, String?>{};
+    String? title = '';
 
     matches.forEach((match) {
       if (match[1] != null && match[2] != null) {
-        attributes[match[1]] = match[2];
+        attributes[match[1]!] = match[2];
       } else if (match[3] != null) {
         title = match[3];
       } else {
         print('ERROR regexing against -> ${match[0]}');
       }
     });
-    return EntryInformation(title: title, attributes: attributes);
+    return EntryInformation(title: title!, attributes: attributes);
   }
 }

--- a/lib/src/playlist_helper.dart
+++ b/lib/src/playlist_helper.dart
@@ -9,8 +9,8 @@ class PlaylistHelper {
   /// [defaultAttribute] when the attribute is not found category
   /// to merge properties.
   static Map<String, List<M3uGenericEntry>> sortedCategories(
-          {@required List<M3uGenericEntry> entries,
-          @required String attributeName,
+          {required List<M3uGenericEntry> entries,
+          required String attributeName,
           String defaultAttribute = 'other'}) =>
       entries.fold(<String, List<M3uGenericEntry>>{}, (acc, current) {
         final property = current.attributes[attributeName] ?? defaultAttribute;
@@ -18,7 +18,7 @@ class PlaylistHelper {
         if (!acc.containsKey(property)) {
           acc[property] = [current];
         } else {
-          acc[property].add(current);
+          acc[property]!.add(current);
         }
         return acc;
       });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ author: Bruno Oliveira <bm.oliveira.dev@gmail.com>
 description: Simple Dart tool to parse M3U and M3U_Plus files from a string or document string.
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   meta: ^1.1.5

--- a/test/generic/invalid_formats_test.dart
+++ b/test/generic/invalid_formats_test.dart
@@ -8,7 +8,7 @@ void main() {
     expect(
         () async => parseFile(
             await FileUtils.loadFile(fileName: 'generic/invalid_header')),
-        throwsA(predicate((exception) =>
+        throwsA(predicate((dynamic exception) =>
             exception is InvalidFormatException &&
             exception.formatType == InvalidFormatType.header)));
   });

--- a/test/plus/parser_test.dart
+++ b/test/plus/parser_test.dart
@@ -16,7 +16,6 @@ void main() {
     expect(testSubject.attributes['group-title'], 'The Only one');
     expect(testSubject.title, 'A TV channel');
     expect(testSubject.link, 'https://vimeo.com/63031638');
-
     expect(testSubject.duration, -1);
   });
 

--- a/test/plus/parser_test.dart
+++ b/test/plus/parser_test.dart
@@ -17,8 +17,7 @@ void main() {
     expect(testSubject.title, 'A TV channel');
     expect(testSubject.link, 'https://vimeo.com/63031638');
 
-    // Missing
-    //#EXTINF:-1
+    expect(testSubject.duration, -1);
   });
 
   test('M3U_Plus multi line file', () async {

--- a/test/simple/parser_test.dart
+++ b/test/simple/parser_test.dart
@@ -10,9 +10,16 @@ void main() {
     final testSubject = playlist[0];
     expect(testSubject.title, 'A TV channel');
     expect(testSubject.link, 'https://vimeo.com/63031638');
+    expect(testSubject.duration, -1);
+  });
 
-    // Missing
-    //#EXTINF:-1
+  test('M3U single line - parsing duration', () async {
+    final playlist = await parseFile(
+        await FileUtils.loadFile(fileName: 'simple/single_line_duration'));
+    final testSubject = playlist[0];
+    expect(testSubject.title, 'A TV channel');
+    expect(testSubject.link, 'https://vimeo.com/63031638');
+    expect(testSubject.duration, 42);
   });
 
   test('M3U multi line file', () async {

--- a/test/utils/file_loader.dart
+++ b/test/utils/file_loader.dart
@@ -2,6 +2,6 @@ import 'dart:io';
 
 class FileUtils {
   static Future<String> loadFile(
-          {String fileName, String extension = '.m3u'}) =>
+          {String? fileName, String extension = '.m3u'}) =>
       File('test_resources/$fileName$extension').readAsString();
 }

--- a/test_resources/simple/single_line_duration.m3u
+++ b/test_resources/simple/single_line_duration.m3u
@@ -1,0 +1,3 @@
+#M3U
+#EXTINF:42,A TV channel
+https://vimeo.com/63031638


### PR DESCRIPTION
This adds a `duration` property to entries. If the number next to `EXTINF` parses, it is set as the duration. If it is not present or fails to parse duration is null.