### PR TITLE
Skip empty lines

### DIFF
--- a/lib/src/m3u_parser.dart
+++ b/lib/src/m3u_parser.dart
@@ -41,7 +41,11 @@ class M3uParser {
   ///
   /// Can [throws] [InvalidFormatException] if the file is not supported.
   Future<List<M3uGenericEntry>> _parse(String source) async {
-    LineSplitter.split(source).forEach(_parseLine);
+    LineSplitter.split(source).forEach((line) {
+      if (line.isNotEmpty) {
+        _parseLine(line);
+      }
+    });
     return _playlist;
   }
 


### PR DESCRIPTION
Hi!

I would like to propose skipping empty lines when parsing a document.

Check out this example from [the Wikipedia page about M3U](https://en.wikipedia.org/wiki/M3U#Examples):

```
#EXTM3U
 
#EXTINF:123, Sample artist - Sample title
C:\Documents and Settings\I\My Music\Sample.mp3
 
#EXTINF:321,Example Artist - Example title
C:\Documents and Settings\I\My Music\Greatest Hits\Example.ogg
```

Right now,  after parsing, the first entry will have the following values:
```
﻿﻿title=""
link="#EXTINF:123, Sample artist - Sample title"
```

Second entry:
```
title=""
link=""
```

Third entry:
```
title="Example Artist - Example title"
link="C:\Documents and Settings\I\My Music\Greatest Hits\Example.ogg"
```


This pull request solves the issue.